### PR TITLE
Rename colliding test

### DIFF
--- a/src/restview/tests.py
+++ b/src/restview/tests.py
@@ -218,7 +218,7 @@ def doctest_RestViewer_get_markup_adds_ajax():
     """
 
 
-def doctest_RestViewer_get_markup_adds_ajax():
+def doctest_RestViewer_get_markup_adds_ajax_with_mtime():
     """Test for RestViewer.get_markup
 
         >>> viewer = RestViewer('.')


### PR DESCRIPTION
There were two instances of `doctest_RestViewer_get_markup_adds_ajax()` defined.
