### PR TITLE
Migrate to argparse and support halt-level

### DIFF
--- a/src/restview/tests.py
+++ b/src/restview/tests.py
@@ -925,8 +925,7 @@ class TestMain(unittest.TestCase):
 
     def test_help(self):
         stdout, stderr = self.run_main('--help')
-        self.assertTrue('restview [options] filename-or-directory' in stdout,
-                        stdout)
+        self.assertTrue('restview [options] root' in stdout, stdout)
 
     def test_error_when_no_arguments(self):
         stdout, stderr = self.run_main(rc=2)


### PR DESCRIPTION
optparser is deprecated in Python 2.7, and argparse should be used
instead.

The --halt-level option will set the docutils' "halt_level" option,
which will give the user finer-grained control. For example, the user
may wish to stop processing at level WARNING rather than INFO.