### PR TITLE
Added __main__.py to execute package with `python -m restview`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added ``__main__.py`` module to allow package to be executable with
+  ``python -m restview``. - SimplyKnownAsG
 
 
 2.8.1 (2018-01-28)

--- a/src/restview/__main__.py
+++ b/src/restview/__main__.py
@@ -1,0 +1,7 @@
+"""
+This module contains the entry point to restview.
+"""
+from restview.restviewhttp import main
+
+if __name__ == '__main__':
+    main()

--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -1,20 +1,5 @@
-#!/usr/bin/python
 """
 HTTP-based ReStructuredText viewer.
-
-Usage:
-    restview [options] filename.rst [...]
-or
-    restview [options] directory [...]
-or
-    restview [options] -e "command" [--watch filename] [...]
-or
-    restview [options] --long-description
-or
-    restview --help
-
-Needs docutils and a web browser. Will syntax-highlight code or doctest blocks
-(needs pygments).
 """
 from __future__ import print_function
 
@@ -682,11 +667,10 @@ def launch_browser(url):
 
 
 def main():
-    progname = os.path.basename(sys.argv[0])
     parser = argparse.ArgumentParser(
                     usage="%(prog)s [options] root [...]",
                     description="Serve ReStructuredText files over HTTP.",
-                    prog=progname)
+                    prog="restview")
     parser.add_argument('root',
                         help='filename or directory to serve documents from',
                         nargs='*')
@@ -792,7 +776,3 @@ def main():
         pass
     finally:
         server.close()
-
-
-if __name__ == '__main__':
-    main()


### PR DESCRIPTION
This addresses #52. I'm not sure if it makes sense to keep the same docstring in this file. I can remove it altogether or shorten to simply:

```python
"""
Usage:
    python -m restview --help
"""
```
given that argparse kinda handles the rest.

Other questions:
1. do you want to remove the `if __name__ == '__main__'` from `restviewhttp.py`?
2. if yes to the above, should I change the setup.py to use `__main__` instead of the `restview.restviewhttp:main`?
3. if yes to the above, should we `chmod -x restviewhttp.py`? (no effect on windows)