### PR TITLE
Docutils 0.18.1: stylesheet vs stylesheet_path

### DIFF
--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -458,8 +458,8 @@ class RestViewer(object):
             stylesheet_dirs = writer.default_stylesheet_dirs + [DATA_PATH]
             # docutils can't embed http:// or https:// URLs
             embed_stylesheet = '//' not in self.stylesheets
-            settings_overrides = {'stylesheet': self.stylesheets,
-                                  'stylesheet_path': None,
+            settings_overrides = {'stylesheet': None,
+                                  'stylesheet_path': self.stylesheets,
                                   'stylesheet_dirs': stylesheet_dirs,
                                   'embed_stylesheet': embed_stylesheet}
         else:

--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -456,12 +456,17 @@ class RestViewer(object):
             writer.translator_class = SyntaxHighlightingHTMLTranslator
         if self.stylesheets:
             stylesheet_dirs = writer.default_stylesheet_dirs + [DATA_PATH]
-            # docutils can't embed http:// or https:// URLs
-            embed_stylesheet = '//' not in self.stylesheets
-            settings_overrides = {'stylesheet': None,
-                                  'stylesheet_path': self.stylesheets,
-                                  'stylesheet_dirs': stylesheet_dirs,
-                                  'embed_stylesheet': embed_stylesheet}
+            if '//' not in self.stylesheets:
+                settings_overrides = {'stylesheet': None,
+                                      'stylesheet_path': self.stylesheets,
+                                      'stylesheet_dirs': stylesheet_dirs,
+                                      'embed_stylesheet': True}
+            else:
+                # docutils can't embed http:// or https:// URLs
+                settings_overrides = {'stylesheet': self.stylesheets,
+                                      'stylesheet_path': None,
+                                      'stylesheet_dirs': stylesheet_dirs,
+                                      'embed_stylesheet': False}
         else:
             settings_overrides = {}
         settings_overrides['syntax_highlight'] = 'short'


### PR DESCRIPTION
Fixes #60 

Looking at the upstream changes, the regression in restview is caused by commit r8891 and more specifically https://sourceforge.net/p/docutils/code/8891/tree//trunk/docutils/docutils/utils/__init__.py?diff=5140ec3227184634283d9030:8890 which disables the stylesheet lookup when stylesheets are passed via `settings.stylesheet` instead than `settings.stylesheet_path`. From https://docutils.sourceforge.io/docs/user/config.html, this was always the expected behavior but the library was lenient and 0.18.1 enforces it.

This PR fixes the behavior by first inferring whether the stylesheets should be used verbatim using the presence of `//` and then setting either `stylesheet_path` or `stylesheet` depending on the use case. Tests should be passing with `docutils 0.18.1` and I expect this change is backwards compatible   although I assume `setup.py` could force `docutils >=0.18.1` for extra cauion.

One scenario that is not handled would be a mixed case e.g. a combination of HTTP(s) stylesheet and local stylesheets. Since it is not possible to pass both `stylesheet` and `stylesheet_path` to docutils, I am not even sure of how one would resolve this or if it is relevant
