### PR TITLE
Use unittest.mock on Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ include release.mk
 
 
 bin/pytest: | bin/pip
-	bin/pip install pytest mock
+	bin/pip install pytest 'mock;python_version<"3.3"'
 	ln -sfr .venv/$@ $@
 
 bin/restview: setup.py | bin/pip

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ setup(
     package_data={'restview': ['*.css', '*.ico']},
     include_package_data=True,
     install_requires=['docutils', 'readme_renderer', 'pygments'],
-    extras_require={'syntax': [], 'test': ['mock']},
+    extras_require={'syntax': [], 'test': ['mock;python_version<"3.3"']},
     test_suite='restview.tests.test_suite',
-    tests_require=['mock'],
+    tests_require=['mock;python_version<"3.3"'],
     zip_safe=False,
     entry_points="""
     [console_scripts]

--- a/src/restview/tests.py
+++ b/src/restview/tests.py
@@ -12,7 +12,11 @@ except ImportError:
     from io import StringIO
 
 import docutils.utils
-from mock import Mock, patch
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 from restview.restviewhttp import (
     MyRequestHandler,


### PR DESCRIPTION
In Fedora, we would like to get rid of the separately packaged mock package.