### PR TITLE
Drop Python 2.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "2.7"
           - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
-          - "pypy2"
           - "pypy3"
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-2.9.4 (unreleased)
+3.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop support for Python 2.7.
 
 
 2.9.3 (2021-11-29)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ include release.mk
 
 
 bin/pytest: | bin/pip
-	bin/pip install pytest mock
+	bin/pip install pytest
 	ln -sfr .venv/$@ $@
 
 bin/restview: setup.py | bin/pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     # https://www.appveyor.com/docs/installed-software#python lists available
     # versions
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,8 @@ setup(
     package_data={'restview': ['*.css', '*.ico']},
     include_package_data=True,
     install_requires=['docutils', 'readme_renderer', 'pygments'],
-    extras_require={'syntax': [], 'test': ['mock']},
+    extras_require={'syntax': [], 'test': []},
     test_suite='restview.tests.test_suite',
-    tests_require=['mock'],
     zip_safe=False,
     entry_points="""
     [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU General Public License (GPL)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -23,7 +23,7 @@ import readme_renderer.rst as readme_rst
 from pygments import formatters, lexers
 
 
-__version__ = '2.9.4.dev0'
+__version__ = '3.0.0.dev0'
 
 
 # If restview is ever packaged for Debian, this'll likely be changed to

--- a/src/restview/tests.py
+++ b/src/restview/tests.py
@@ -4,12 +4,7 @@ import os
 import socket
 import unittest
 import webbrowser
-
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 import docutils.utils
 from mock import Mock, patch
@@ -21,12 +16,6 @@ from restview.restviewhttp import (
     launch_browser,
     main,
 )
-
-
-try:
-    unicode
-except NameError:
-    unicode = str
 
 
 class PopenStub(object):
@@ -54,9 +43,9 @@ class MyRequestHandlerForTests(MyRequestHandler):
         self.server.renderer.watch = None
         self.server.renderer.allowed_hosts = ['localhost']
         self.server.renderer.rest_to_html = lambda data, mtime=None, filename=None: \
-            unicode('HTML for %s with AJAX poller for %s' % (data, mtime))
+            'HTML for %s with AJAX poller for %s' % (data, mtime)
         self.server.renderer.render_exception = lambda title, error, source, mtime=None: \
-            unicode('HTML for error %s: %s: %s' % (title, error, source))
+            'HTML for error %s: %s: %s' % (title, error, source)
 
     def send_response(self, status):
         self.status = status
@@ -463,9 +452,9 @@ class TestMyRequestHandler(unittest.TestCase):
         handler = MyRequestHandlerForTests()
         handler.collect_files = lambda dir: ['a.txt', 'b/c.txt']
         handler.render_dir_listing = lambda title, files: \
-            unicode("<title>%s</title>\n%s" % (
+            "<title>%s</title>\n%s" % (
                 title,
-                '\n'.join('%s - %s' % (path, fn) for path, fn in files)))
+                '\n'.join('%s - %s' % (path, fn) for path, fn in files))
         body = handler.handle_dir('/path/to/dir')
         self.assertEqual(handler.status, 200)
         self.assertEqual(handler.headers['Content-Type'],
@@ -482,9 +471,9 @@ class TestMyRequestHandler(unittest.TestCase):
         handler = MyRequestHandlerForTests()
         handler.collect_files = lambda dir: ['a.txt', os.path.join('b', 'c.txt')]
         handler.render_dir_listing = lambda title, files: \
-            unicode("<title>%s</title>\n%s" % (
+            "<title>%s</title>\n%s" % (
                 title,
-                '\n'.join('%s - %s' % (path, fn) for path, fn in files)))
+                '\n'.join('%s - %s' % (path, fn) for path, fn in files))
         with patch('os.path.isdir', lambda fn: fn == 'subdir'):
             body = handler.handle_list([os.path.normpath('/path/to/file.txt'),
                                         'subdir'])

--- a/src/restview/tests.py
+++ b/src/restview/tests.py
@@ -5,9 +5,9 @@ import socket
 import unittest
 import webbrowser
 from io import StringIO
+from unittest.mock import Mock, patch
 
 import docutils.utils
-from mock import Mock, patch
 
 from restview.restviewhttp import (
     MyRequestHandler,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py36,py37,py38,py39,py310,pypy,pypy3
+    py36,py37,py38,py39,py310,pypy3
 
 [testenv]
 extras = test


### PR DESCRIPTION
It is time.

Also drops the `mock` dependency, superseding #62.