### PR TITLE
Read config defaults from a config file

### DIFF
--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -727,6 +727,17 @@ class ConfigFileHandler:
         return {}
 
     @classmethod
+    def join_opts(cls, cli_opts, config_opts):
+        """Join dictionaries containing CLI & config options
+
+        CLI options override config options if provided (left joined)
+        """
+        opts = dict(config_opts)
+        opts.update({k: v for k, v in cli_opts.items()
+                    if k not in opts or v not in (None, False, [], '')})
+        return opts
+
+    @classmethod
     def csvs_to_list(cls, csvs):
         """Split comma-separeted values into a list"""
         if csvs is None:

--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -2,6 +2,7 @@
 HTTP-based ReStructuredText viewer.
 """
 import argparse
+import configparser
 import fnmatch
 import http.server
 import os
@@ -14,6 +15,7 @@ import threading
 import time
 import webbrowser
 from html import escape
+from pathlib import Path
 from urllib.parse import parse_qs, unquote
 
 import docutils.core
@@ -24,6 +26,10 @@ from pygments import formatters, lexers
 
 
 __version__ = '3.0.3.dev0'
+
+
+CONFIG_FILE_PATH = Path.home() / '.restview.ini'
+CONFIG_OPTIONS_SECTION = 'DEFAULT'
 
 
 # If restview is ever packaged for Debian, this'll likely be changed to
@@ -648,6 +654,30 @@ def launch_browser(url):
     t.setDaemon(True)
     t.start()
 
+
+class ConfigFileHandler:
+    """Creates config files and reads default options"""
+
+    # Default template for newly-created config files
+    # Contains commented out sample key/value option pairs
+    CONFIG_FILE_TEMPLATE = (
+        "# for options description, refer to the original docs at "
+        "https://github.com/calismu/restview/blob/master/README.rst#synopsis\n\n"
+        "[DEFAULT]\n"
+        "# listen = *:8080\n"
+        "# allowed_hosts = 1.2.3.4,LOCALHOST\n"
+        "# browser = true\n"
+        "# watch = file1.rst,file2.rst,file3.rst\n"
+        "# long_description = true\n"
+        "# css = sheet1.css,sheet2.css\n"
+        "# pypi_strict = FALSE\n"
+        "# halt_level = 2\n"
+    )
+
+    def __init__(self, config_file_path, opts_sect):
+        self.config_file_path = config_file_path
+        self.opts_section = opts_sect
+        self.parser = configparser.ConfigParser()
 
 def main():
     parser = argparse.ArgumentParser(

--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -811,7 +811,14 @@ def main():
         '--pypi-strict',
         help='enable additional restrictions that PyPI performs',
         action='store_true', default=False)
-    opts = parser.parse_args(sys.argv[1:])
+    cli_opts = parser.parse_args(sys.argv[1:])
+
+    cf_handler = ConfigFileHandler(CONFIG_FILE_PATH, CONFIG_OPTIONS_SECTION)
+    cf_handler.create_config_file()
+    config_file_opts = cf_handler.read_opts()
+    opts = argparse.Namespace(
+        **cf_handler.join_opts(vars(cli_opts), config_file_opts))
+
     args = opts.root
     if opts.long_description:
         opts.execute = 'python setup.py --long-description'

--- a/src/restview/restviewhttp.py
+++ b/src/restview/restviewhttp.py
@@ -679,6 +679,15 @@ class ConfigFileHandler:
         self.opts_section = opts_sect
         self.parser = configparser.ConfigParser()
 
+    def create_config_file(self):
+        """Create ~/{config_file_name} if not exists
+
+        CONFIG_FILE_TEMPLATE is the content of the file created
+        """
+        if not self.config_file_path.exists():
+            self.config_file_path.write_text(
+                ConfigFileHandler.CONFIG_FILE_TEMPLATE)
+
 def main():
     parser = argparse.ArgumentParser(
                     usage="%(prog)s [options] root [...]",

--- a/src/restview/tests.py
+++ b/src/restview/tests.py
@@ -1075,6 +1075,27 @@ class TestCofigFileHandler(unittest.TestCase):
             m_open.assert_called_once_with(self.cfh.config_file_path)
             self.assertDictEqual(result, expected)
 
+    def test_join_opts(self):
+        cli_opts = {
+            'listen': None,
+            'allowed_hosts': ['localhost', '127.0.0.1'],
+            'strict': True,
+            'stylesheets': [],
+        }
+        config_opts = {
+            'listen': '8080',
+            'strict': False,
+        }
+        opts = ConfigFileHandler.join_opts(cli_opts, config_opts)
+        expected = {
+            'stylesheets': [],
+            'allowed_hosts': ['localhost', '127.0.0.1'],
+            'listen': '8080',
+            'strict': True,
+        }
+        self.assertDictEqual(opts, expected)
+
+
 def grep(needle, haystack):
     for line in haystack.splitlines():
         if needle in line:


### PR DESCRIPTION
### Realizes feature request in title and Closes #67

## Purpose
Reads default config options from an ini file. Should help occasional users of restview avoid recalling CLI options each time they use it

## Steps on startup in restviewhttp.main
1. Instantiate a ConfigFileHandler instance with a file path and an ini section name
2. Create `~/.restview.ini` if it doesn’t exist. Contains commented out options and their respective description (Refer to `ConfigFileHandler.CONFIG_TEMPLATE`)
3. Read, parse, and type-coerce (lists too) config options from `~/.restview.ini`
4. Join CLI and config file options, prioritizing CLI options if provided

## CLI params excluded from config file
- `root` required positional argument, not a config option
- `--execute` not a config option, mutually exclusive with `root`
- `--version` not a config option
- `--no-browser` included browser option could be set to False instead
- `--strict` halt_level options could be set to 2 instead
- `--report-level` has an argparse default value of 2 (not None),
    thus will override config file equivalent options, undistinguishable

## Tests

- Added logic has corresponding tests in `tests.py`. While succinct, these tests exaustively cover the majority of cases
- The feature was manually tested Ubuntu 24.04

## Notes
- Code changes were meant to add no external dependencies, no additional repo modules/files, and not intervene with `argparse` CLI options handling logic in `restviewhttp.main`